### PR TITLE
Add minimal Dockerfile for CI builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ghcr.io/stefan-hoeck/idris2-pack:latest
+
+RUN mkdir -p /opt/irpn
+
+WORKDIR /opt/irpn
+
+COPY irpn.ipkg .
+COPY src       src
+RUN  true
+
+RUN pack build irpn.ipkg


### PR DESCRIPTION
Tested locally, and it worked on the first try, shockingly.